### PR TITLE
Fix shared strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from './lib/xlsx';
+export { default } from './lib/Xlsx';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from './lib/Xlsx';
+export { default } from './lib';

--- a/src/lib/Sheet.ts
+++ b/src/lib/Sheet.ts
@@ -4,6 +4,7 @@ import {
 	IRowTemplateValues
 } from '../templates/sheet';
 import SharedStrings from './SharedStrings';
+import { XLSXValueTypes } from '../utils';
 
 export type XLSXValue = string | number;
 
@@ -14,8 +15,7 @@ export interface IRowValues {
 interface ISheet {
 	rowCount: number;
 	sheetData: string;
-	// addRowFromObject: (values: IRowValues) => string;
-	addFromArray: (values: XLSXValue[]) => string;
+	addRow: (values: XLSXValue[]) => string;
 }
 
 class Sheet implements ISheet {
@@ -29,82 +29,16 @@ class Sheet implements ISheet {
 		this.rowCount = 0;
 	}
 
-	/**
-	 *
-	 * @param values - Values to append to the sheet
-	 * 
-	 * Receives an object where the `key` is equivalent to a Sheet
-	 * column and the `value` to the current row value at the given
-	 * `key`.
-	 * 
-	 * Eg:
-	 * ```
-	 * const row = {
-	 *   name: 'Esteban'
-	 * }
-	 * 
-	 * sheet.addRowFromObject(row);
-	 * ```
-	 * 
-	 * Will add the following to the Sheet:
-	 * 
-	 * | name    |
-	 * | ------- |
-	 * | Esteban |
-	 * 
-	 */
-	// public addRowFromObject(values: IRowValues): string {
-	// 	let isFirstAdd = false;
-
-	// 	if (this.headers.length === 0 && this.rowCount === 0) {
-	// 		// Adds the first row to the XLSX file given an object
-
-	// 		isFirstAdd = true;
-	// 		this.rowCount++;
-	// 		this.headers = Object.keys(values);
-	// 		this.sheetData += row(this.rowCount, Object.keys(values) as unknown as IRowTemplateValues[]);
-	// 		this.columnValueTypes = this.getValueTypes(values);
-	// 	}
-
-	// 	this.rowCount++;
-	// 	let currentRow = row(this.rowCount, this.headers.map((header) => values[header]));
-	// 	this.sheetData += currentRow;
-
-	// 	if (isFirstAdd) {
-	// 		// The first time a row is added, return the complete header and data of the sheet
-	// 		return this.sheetData;
-	// 	}
-
-	// 	// Otherwise returns the recently created row
-	// 	return currentRow;
-	// }
-
-	/**
-	 * 
-	 * @param values - Values to append to the current sheet
-	 * 
-	 * Receives an array of values and appends it to the current sheet.
-	 * 
-	 * Note: Values should be aligned with the column order, otherwise
-	 * columns will mismatch values in the resulting sheet.
-	 * 
-	 * In order to keep values aligned with columns use `addRowsFromObject`
-	 * instead.
-	 */
-	public addFromArray(values: XLSXValue[]): string {
-		return this.addRow(values);
-	}
-
-	private addRow(values: XLSXValue[]): string {
+	public addRow(values: XLSXValue[]): string {
 		let rowValues = values.map((value: XLSXValue) => {
 			let valueType = typeof value;
 			let finalValue;
 
-			if (valueType === 'string') {
+			if (valueType === XLSXValueTypes.string) {
 				finalValue = this.sharedStrings.fromString(value as string);
 			}
 
-			if (valueType === 'number') {
+			if (valueType === XLSXValueTypes.number) {
 				finalValue = value;
 			}
 
@@ -115,9 +49,9 @@ class Sheet implements ISheet {
 		});
 
 		this.rowCount++;
-		const rowString =  row(this.rowCount, rowValues as IRowTemplateValues[]);
+		const rowString = row(this.rowCount, rowValues as IRowTemplateValues[]);
 		this.sheetData += rowString;
-		
+
 		return rowString;
 	}
 }

--- a/src/lib/Sheet.ts
+++ b/src/lib/Sheet.ts
@@ -2,6 +2,7 @@ import {
 	header as createXMLHeader,
 	row
 } from '../templates/sheet';
+import SharedStrings from './SharedStrings';
 
 export type XLSXValue = string | number;
 
@@ -12,6 +13,7 @@ export interface IRowValues {
 interface ISheet {
 	rowCount: number;
 	addRowFromObject: (values: IRowValues) => string;
+	addFromArray: (values: XLSXValue[]) => string;
 }
 
 class Sheet implements ISheet {
@@ -71,6 +73,34 @@ class Sheet implements ISheet {
 			return this.sheetData;
 		}
 
+		// Otherwise returns the recently created row
+		return currentRow;
+	}
+
+	/**
+	 * 
+	 * @param values - Values to append to the current sheet
+	 * 
+	 * Receives an array of values and appends it to the current sheet.
+	 * 
+	 * Note: Values should be aligned with the column order, otherwise
+	 * columns will mismatch values in the resulting sheet.
+	 * 
+	 * In order to keep values aligned with columns use `addRowsFromObject`
+	 * instead.
+	 */
+	public addFromArray(values: XLSXValue[]): string {
+		if (this.headers.length === 0 && this.rowCount === 0) {
+			this.rowCount++;
+			this.sheetData += row(this.rowCount, values);
+
+			// The first time a row is added, return the complete header and data of the sheet
+			return this.sheetData;
+		}
+
+		this.rowCount++;
+		const currentRow = row(this.rowCount, values);
+		
 		// Otherwise returns the recently created row
 		return currentRow;
 	}

--- a/src/lib/Sheet.ts
+++ b/src/lib/Sheet.ts
@@ -52,6 +52,10 @@ class Sheet implements ISheet {
 		const rowString = row(this.rowCount, rowValues as IRowTemplateValues[]);
 		this.sheetData += rowString;
 
+		if (this.rowCount === 0) {
+			return this.sheetData;
+		}
+
 		return rowString;
 	}
 }

--- a/src/lib/Xlsx.ts
+++ b/src/lib/Xlsx.ts
@@ -1,14 +1,10 @@
 import Archiver, { Archiver as IArchiver } from 'archiver';
 import { PassThrough } from 'stream';
-import Sheet, { IRowValues } from './Sheet';
+import Sheet, { XLSXValue } from './Sheet';
 import * as template from '../templates';
 import SharedStrings from './SharedStrings';
 
 export interface IXlsx {}
-
-interface IRowDataNormalizeOptions {
-	withHeaders: boolean;
-}
 
 class Xlsx implements IXlsx {
 	private xlsxFile: IArchiver;
@@ -16,28 +12,15 @@ class Xlsx implements IXlsx {
 	private sheet: Sheet;
 	private sharedStrings: SharedStrings;
 
-	constructor(sharedStrings: SharedStrings) {
+	constructor() {
 		this.xlsxFile = Archiver('zip');
 		this.sharedStrings = new SharedStrings();
-		this.sheet = new Sheet(sharedStrings);
+		this.sheet = new Sheet(this.sharedStrings);
 		this.sheetStream = new PassThrough({ objectMode: true });
 
-		// Append the first sheet of the XLSX file
-		// to the ZIP.
 		this.xlsxFile.append(this.sheetStream, {
 			name: 'xl/worksheets/sheet1.xml'
 		});
-	}
-
-	public addRow(rowData: IRowValues): void {
-		if (this.sheet.rowCount === 0) {
-			// Register shared strings for the file headers
-			this.sheetStream.write(this.sheet.addRowFromObject(this.normalize(rowData, {
-				withHeaders: true
-			})));
-		}
-
-		this.sheetStream.write(this.sheet.addRowFromObject(this.normalize(rowData)));
 	}
 
 	public getStream(): IArchiver {
@@ -64,29 +47,8 @@ class Xlsx implements IXlsx {
 		// Missing xl/worksheets/_rels/sheet1.xml.rels
 	}
 
-	private normalize(original: IRowValues, options?: IRowDataNormalizeOptions): IRowValues {
-		let normalizedObject: any = {};
-		const originalKeys = Object.keys(original);
-
-		if (options && options.withHeaders) {
-			const columnHeaders = Object.keys(original);
-
-			for (let i = 0; i < columnHeaders.length; i++) {
-				this.sharedStrings.fromString(columnHeaders[i]);
-			}
-		}
-
-		for (let i = 0; i < originalKeys.length; i++) {
-			const key = originalKeys[i];
-
-			if (typeof original[key] === 'string') {
-				normalizedObject[key] = this.sharedStrings.fromString(original[key] as string);
-			} else {
-				normalizedObject[key] = original[key];
-			}
-		}
-
-		return normalizedObject;
+	public addRow(values: XLSXValue[]): void {
+		this.sheetStream.write(this.sheet.addRow(values));
 	}
 }
 

--- a/src/lib/Xlsx.ts
+++ b/src/lib/Xlsx.ts
@@ -16,10 +16,10 @@ class Xlsx implements IXlsx {
 	private sheet: Sheet;
 	private sharedStrings: SharedStrings;
 
-	constructor() {
+	constructor(sharedStrings: SharedStrings) {
 		this.xlsxFile = Archiver('zip');
 		this.sharedStrings = new SharedStrings();
-		this.sheet = new Sheet();
+		this.sheet = new Sheet(sharedStrings);
 		this.sheetStream = new PassThrough({ objectMode: true });
 
 		// Append the first sheet of the XLSX file

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Xlsx';
+export { default as SharedStrings } from './SharedStrings';
+export { default as Sheet } from './Sheet';

--- a/src/templates/sheet.ts
+++ b/src/templates/sheet.ts
@@ -1,4 +1,10 @@
-import { toOneLine, getColumnIndex, getCellValueType } from '../utils';
+import { toOneLine, getColumnIndex, getCellValueType, XLSXValueTypes } from '../utils';
+import { XLSXValue } from '../lib/Sheet';
+
+export interface IRowTemplateValues {
+	value: XLSXValue;
+	type: XLSXValueTypes;
+}
 
 /**
  * 
@@ -31,10 +37,10 @@ export const header = (dimensions: string) => toOneLine(`
  * Returns the XML-XLSX row template
  * 
  */
-export const row = (rowIndex: number, values: Array<string | number>): string => {
+export const row = (rowIndex: number, values: IRowTemplateValues[]): string => {
 	let _row = `<row r="${rowIndex}" ht="13" hidden="false" customHeight="false" outlineLevel="0" collapsed="false">`;
-	_row = _row.concat(values.map((cellValue, index) => (
-		`<c r="${getColumnIndex(index)}${rowIndex}" t="${getCellValueType(cellValue)}"><v>${cellValue}</v></c>`
+	_row = _row.concat(values.map((rowObj: IRowTemplateValues, index) => (
+		`<c r="${getColumnIndex(index)}${rowIndex}" t="${getCellValueType(rowObj.type)}"><v>${rowObj.value}</v></c>`
 	)).join('')).concat('</row>');
 
 	return _row;

--- a/src/utils/getCellValueType.ts
+++ b/src/utils/getCellValueType.ts
@@ -1,3 +1,8 @@
+export enum XLSXValueTypes {
+	string = 'string',
+	number = 'number'
+}
+
 /**
  * 
  * @param value - Value to evaluate
@@ -6,14 +11,14 @@
  * If a value is invalid for a XLSX Row throws an exception.
  * 
  */
-function getCellValueType(value: any): string {
-	switch (typeof value) {
+function getCellValueType(valueType: XLSXValueTypes): string {
+	switch (valueType) {
 		case 'string':
 			return 's';
 		case 'number':
 			return 'n';
 		default:
-			throw new Error(`Invalid value of type ${typeof value}. Valid types are "string", "number".`);
+			throw new Error(`Unable to get value type for ${valueType}`);
 	}
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { default as toOneLine } from './toOneLine';
 export { default as getColumnIndex } from './getColumnIndex';
-export { default as getCellValueType } from './getCellValueType';
+export { default as getCellValueType, XLSXValueTypes } from './getCellValueType';

--- a/tests/Xlsx.test.ts
+++ b/tests/Xlsx.test.ts
@@ -22,10 +22,10 @@ stream.on('finish', () => {
 	console.log(`finished @ ${new Date().toISOString()}`);
 });
 
-file.addRow({
-	foo: 'bar',
-	bar: 1
-});
+file.addRow(['foo', 1, 'bar', 30.0]);
+file.addRow(['foo1', 2, 'bar1', 30.0]);
+file.addRow(['foo2', 3, 'bar2', 30.0]);
+file.addRow(['foo', 4, 'bar', 30.0]);
 
 file.build().then(() => {
 	console.log('BUILDED');

--- a/tests/lib/Sheet.test.ts
+++ b/tests/lib/Sheet.test.ts
@@ -42,3 +42,19 @@ describe('lib :: Sheet :: addRowFromObject', () => {
 		expect(secondRow).toBe('<row r=\"3\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A3\" t=\"s\"><v>zoo</v></c></row>');
 	});	
 });
+
+describe('lib :: Sheet :: addFromArray', () => {
+	let sheet: Sheet;
+	
+	beforeEach(() => {
+		sheet = new Sheet();
+	});
+
+	it('returns the xml header with the first row at the first append', () => {
+		const created = sheet.addFromArray(['foo']);
+
+		const want = `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <worksheet  xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"   xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" > <dimension ref=\"A1\"/> <sheetViews>  <sheetView workbookViewId=\"0\"/> </sheetViews> <sheetFormatPr defaultRowHeight=\"12.8\"></sheetFormatPr> <cols>  <col collapsed=\"false\" hidden=\"false\" max=\"1025\" min=\"1\" style=\"0\" width=\"12\" /> </cols> <sheetData><row r=\"1\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A1\" t=\"s\"><v>foo</v></c></row>`;
+	
+		expect(created).toBe(want);
+	});
+});

--- a/tests/lib/Sheet.test.ts
+++ b/tests/lib/Sheet.test.ts
@@ -1,10 +1,11 @@
-import Sheet from '../../src/lib/Sheet';
+import { Sheet, SharedStrings } from '../../src/lib';
 
 describe('lib :: Sheet', () => {
 	let sheet: Sheet;
+	let sharedStrings: SharedStrings;
 	
 	beforeEach(() => {
-		sheet = new Sheet();
+		sheet = new Sheet(sharedStrings);
 	});
 
 	it('initializes sheet header when creating a new Sheet instance', () => {
@@ -14,81 +15,23 @@ describe('lib :: Sheet', () => {
 	});
 });
 
-describe('lib :: Sheet :: addRowFromObject', () => {
+describe('lib :: Sheet :: addRow', () => {
 	let sheet: Sheet;
+	let sharedStrings: SharedStrings;
 	
 	beforeEach(() => {
-		sheet = new Sheet();
+		sharedStrings = new SharedStrings();
+		sheet = new Sheet(sharedStrings);
 	});
 
-	it('returns the header and appended row when the first row is added', () => {
-		const created = sheet.addRowFromObject({
-			foo: 'bar'
-		});
-		const want = `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <worksheet  xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"   xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" > <dimension ref=\"A1\"/> <sheetViews>  <sheetView workbookViewId=\"0\"/> </sheetViews> <sheetFormatPr defaultRowHeight=\"12.8\"></sheetFormatPr> <cols>  <col collapsed=\"false\" hidden=\"false\" max=\"1025\" min=\"1\" style=\"0\" width=\"12\" /> </cols> <sheetData><row r=\"1\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A1\" t=\"s\"><v>foo</v></c></row><row r=\"2\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A2\" t=\"s\"><v>bar</v></c></row>`;
-	
-		expect(created).toBe(want);
-	});
+	it('adds the new row to the sheet and returns the new row', () => {
+		expect.assertions(2);
 
-	it('returns the appended row', () => {
-		sheet.addRowFromObject({
-			foo: 'bar'
-		});
+		const have = sheet['addRow'](['foo', 1, 'bar', 30.00]);
+		const addedRow = `<row r=\"1\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A1\" t=\"s\"><v>0</v></c><c r=\"B1\" t=\"n\"><v>1</v></c><c r=\"C1\" t=\"s\"><v>1</v></c><c r=\"D1\" t=\"n\"><v>30</v></c></row>`;
+		const sheetData = `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <worksheet  xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"   xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" > <dimension ref=\"A1\"/> <sheetViews>  <sheetView workbookViewId=\"0\"/> </sheetViews> <sheetFormatPr defaultRowHeight=\"12.8\"></sheetFormatPr> <cols>  <col collapsed=\"false\" hidden=\"false\" max=\"1025\" min=\"1\" style=\"0\" width=\"12\" /> </cols> <sheetData><row r=\"1\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A1\" t=\"s\"><v>0</v></c><c r=\"B1\" t=\"n\"><v>1</v></c><c r=\"C1\" t=\"s\"><v>1</v></c><c r=\"D1\" t=\"n\"><v>30</v></c></row>`;
 
-		const secondRow = sheet.addRowFromObject({
-			foo: 'zoo'
-		});
-
-		expect(secondRow).toBe('<row r=\"3\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A3\" t=\"s\"><v>zoo</v></c></row>');
-	});	
-});
-
-describe('lib :: Sheet :: addFromArray', () => {
-	let sheet: Sheet;
-	
-	beforeEach(() => {
-		sheet = new Sheet();
-	});
-
-	it('returns the xml header with the first row at the first append', () => {
-		const created = sheet.addFromArray(['foo']);
-
-		const want = `<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <worksheet  xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"   xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" > <dimension ref=\"A1\"/> <sheetViews>  <sheetView workbookViewId=\"0\"/> </sheetViews> <sheetFormatPr defaultRowHeight=\"12.8\"></sheetFormatPr> <cols>  <col collapsed=\"false\" hidden=\"false\" max=\"1025\" min=\"1\" style=\"0\" width=\"12\" /> </cols> <sheetData><row r=\"1\" ht=\"13\" hidden=\"false\" customHeight=\"false\" outlineLevel=\"0\" collapsed=\"false\"><c r=\"A1\" t=\"s\"><v>foo</v></c></row>`;
-	
-		expect(created).toBe(want);
-	});
-});
-
-
-describe('lib :: Sheet :: getValueTypes', () => {
-	const expectedValues = {
-		firstName: 'string',
-		lastName: 'string',
-		age: 'number',
-		year: 'number'
-	}
-
-	let sheet: Sheet;
-	
-	beforeEach(() => {
-		sheet = new Sheet();
-		sheet['headers'] = ['firstName', 'lastName', 'age', 'year'];
-	});
-
-	it('gather value types from an array of values', () => {
-		const columnValueTypes = sheet['getValueTypes'](['John', 'Appleseed', 45, 2019]);
-
-		expect(columnValueTypes).toEqual(expectedValues);
-	});
-
-	it('gather value types from an object of values', () => {
-		const columnValueTypes = sheet['getValueTypes']({
-			firstName: 'Contoso',
-			lastName: 'University',
-			age: 20,
-			year: 1999
-		});
-
-		expect(columnValueTypes).toEqual(expectedValues);
+		expect(sheet['sheetData']).toBe(sheetData);
+		expect(have).toBe(addedRow);
 	});
 });

--- a/tests/lib/Sheet.test.ts
+++ b/tests/lib/Sheet.test.ts
@@ -58,3 +58,37 @@ describe('lib :: Sheet :: addFromArray', () => {
 		expect(created).toBe(want);
 	});
 });
+
+
+describe('lib :: Sheet :: getValueTypes', () => {
+	const expectedValues = {
+		firstName: 'string',
+		lastName: 'string',
+		age: 'number',
+		year: 'number'
+	}
+
+	let sheet: Sheet;
+	
+	beforeEach(() => {
+		sheet = new Sheet();
+		sheet['headers'] = ['firstName', 'lastName', 'age', 'year'];
+	});
+
+	it('gather value types from an array of values', () => {
+		const columnValueTypes = sheet['getValueTypes'](['John', 'Appleseed', 45, 2019]);
+
+		expect(columnValueTypes).toEqual(expectedValues);
+	});
+
+	it('gather value types from an object of values', () => {
+		const columnValueTypes = sheet['getValueTypes']({
+			firstName: 'Contoso',
+			lastName: 'University',
+			age: 20,
+			year: 1999
+		});
+
+		expect(columnValueTypes).toEqual(expectedValues);
+	});
+});


### PR DESCRIPTION
Instances a `SharedStrings` object per `Xlsx` object instead of per `Sheet` object, which means that every sheet in a Xlsx file will use the same `SharedStrings` object.

Also fixes issue where the first row's strings wasn't being registered into `SharedStrings` causing unexpected use of `Sheet`.

Removes `addFromObject` and `addFromArray` and implements `addRow` into `Sheet` making it responsible of registering its own rows using an array of `XLSXValues`. Support for Object and sheet column headers will be added in the future, for now, appends rows without input data normalization.